### PR TITLE
Fix single quote HTML escape mapping

### DIFF
--- a/api/carpool.js
+++ b/api/carpool.js
@@ -2,7 +2,8 @@
 import nodemailer from 'nodemailer';
 
 function escapeHtml(str = ''){
-  return String(str).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+  const map = {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};
+  return String(str).replace(/[&<>"']/g, c => map[c]);
 }
 
 export default async function handler(req, res){

--- a/api/send.js
+++ b/api/send.js
@@ -2,7 +2,8 @@
 import nodemailer from 'nodemailer';
 
 function escapeHtml(str = ''){
-  return String(str).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+    const map = {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};
+    return String(str).replace(/[&<>"']/g, c => map[c]);
 }
 
 export default async function handler(req, res){

--- a/chat.js
+++ b/chat.js
@@ -17,7 +17,8 @@ const db = getDatabase(app);
 const messagesRef = ref(db, 'chat-messages');
 
 function escapeHtml(str){
-  return str.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+  const map = {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};
+  return str.replace(/[&<>"']/g, c => map[c]);
 }
 
 const list = document.getElementById('chatList');

--- a/netlify/functions/carpool.js
+++ b/netlify/functions/carpool.js
@@ -2,7 +2,8 @@
 const nodemailer = require('nodemailer');
 
 function escapeHtml(str = ''){
-  return String(str).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+  const map = {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};
+  return String(str).replace(/[&<>"']/g, c => map[c]);
 }
 
 exports.handler = async (event) => {

--- a/netlify/functions/send-email.js
+++ b/netlify/functions/send-email.js
@@ -2,7 +2,8 @@
 const nodemailer = require('nodemailer');
 
 function escapeHtml(str = ''){
-  return String(str).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
+  const map = {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};
+  return String(str).replace(/[&<>"']/g, c => map[c]);
 }
 
 exports.handler = async (event) => {


### PR DESCRIPTION
## Summary
- fix HTML escape maps to use a real single quote key
- refactor escapeHtml to reuse a map

## Testing
- `node - <<'NODE'
function escapeHtml(str = ''){
  const map = {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};
  return String(str).replace(/[&<>"']/g, c => map[c]);
}
console.log(escapeHtml("l'ami"));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689e27f0a8f8832fa97bcd5c386f4711